### PR TITLE
AWS Lambda support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+/.bundle/
+/lambda.zip
+/vendor/

--- a/Gemfile
+++ b/Gemfile
@@ -4,7 +4,3 @@ gem 'rack', "~> 1.6.11"
 gem 'sinatra'
 gem 'json'
 gem 'oauth2'
-
-group :development do
-  gem 'rerun'
-end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -3,12 +3,8 @@ GEM
   specs:
     faraday (0.17.0)
       multipart-post (>= 1.2, < 3)
-    ffi (1.11.1)
     json (2.2.0)
     jwt (2.2.1)
-    listen (3.2.0)
-      rb-fsevent (~> 0.10, >= 0.10.3)
-      rb-inotify (~> 0.9, >= 0.9.10)
     multi_json (1.14.1)
     multi_xml (0.6.0)
     multipart-post (2.1.1)
@@ -21,11 +17,6 @@ GEM
     rack (1.6.11)
     rack-protection (1.5.5)
       rack
-    rb-fsevent (0.10.3)
-    rb-inotify (0.10.0)
-      ffi (~> 1.0)
-    rerun (0.13.0)
-      listen (~> 3.0)
     sinatra (1.4.8)
       rack (~> 1.5)
       rack-protection (~> 1.4)
@@ -39,7 +30,6 @@ DEPENDENCIES
   json
   oauth2
   rack (~> 1.6.11)
-  rerun
   sinatra
 
 BUNDLED WITH

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,9 @@
+.PHONY: lambda.zip
+
+lambda.zip:
+	@rm -f $@
+	@bundle install --deployment
+	@zip -r $@ lambda.rb app vendor
+
+clean:
+	rm -rf .bundle lambda.zip vendor

--- a/app/config.ru
+++ b/app/config.ru
@@ -1,0 +1,4 @@
+require 'rack'
+require_relative './app'
+
+run Sinatra::Application

--- a/lambda.rb
+++ b/lambda.rb
@@ -1,0 +1,97 @@
+# MIT No Attribution
+
+# Permission is hereby granted, free of charge, to any person obtaining a copy of this
+# software and associated documentation files (the "Software"), to deal in the Software
+# without restriction, including without limitation the rights to use, copy, modify,
+# merge, publish, distribute, sublicense, and/or sell copies of the Software, and to
+# permit persons to whom the Software is furnished to do so.
+
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED,
+# INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A
+# PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+# HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+# OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+# SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+require 'json'
+require 'rack'
+require 'base64'
+
+# Global object that responds to the call method. Stay outside of the handler
+# to take advantage of container reuse
+$app ||= Rack::Builder.parse_file("#{__dir__}/app/config.ru").first
+ENV['RACK_ENV'] ||= 'production'
+
+
+def handler(event:, context:)
+  # Check if the body is base64 encoded. If it is, try to decode it
+  body = if event['isBase64Encoded']
+    Base64.decode64 event['body']
+  else
+    event['body']
+  end || ''
+
+  # Rack expects the querystring in plain text, not a hash
+  headers = event.fetch 'headers', {}
+
+  # Environment required by Rack (http://www.rubydoc.info/github/rack/rack/file/SPEC)
+  env = {
+    'REQUEST_METHOD' => event.fetch('httpMethod'),
+    'SCRIPT_NAME' => '',
+    'PATH_INFO' => event.fetch('path', ''),
+    'QUERY_STRING' => Rack::Utils.build_query(event['queryStringParameters'] || {}),
+    'SERVER_NAME' => headers.fetch('Host', 'localhost'),
+    'SERVER_PORT' => headers.fetch('X-Forwarded-Port', 443).to_s,
+
+    'rack.version' => Rack::VERSION,
+    'rack.url_scheme' => headers.fetch('CloudFront-Forwarded-Proto') { headers.fetch('X-Forwarded-Proto', 'https') },
+    'rack.input' => StringIO.new(body),
+    'rack.errors' => $stderr,
+  }
+
+  # Pass request headers to Rack if they are available
+  headers.each_pair do |key, value|
+    # 'CloudFront-Forwarded-Proto' => 'CLOUDFRONT_FORWARDED_PROTO'
+    # Content-Type and Content-Length are handled specially per the Rack SPEC linked above.
+    name = key.upcase.gsub '-', '_'
+    header = case name
+      when 'CONTENT_TYPE', 'CONTENT_LENGTH'
+        name
+      else
+        "HTTP_#{name}"
+    end
+    env[header] = value.to_s
+  end
+
+  begin
+    # Response from Rack must have status, headers and body
+    status, headers, body = $app.call env
+
+    # body is an array. We combine all the items to a single string
+    body_content = ""
+    body.each do |item|
+      body_content += item.to_s
+    end
+
+    # We return the structure required by AWS API Gateway since we integrate with it
+    # https://docs.aws.amazon.com/apigateway/latest/developerguide/set-up-lambda-proxy-integrations.html
+    response = {
+      'statusCode' => status,
+      'headers' => headers,
+      'body' => body_content
+    }
+    if event['requestContext'].has_key?('elb')
+      # Required if we use Application Load Balancer instead of API Gateway
+      response['isBase64Encoded'] = false
+    end
+  rescue Exception => exception
+    # If there is _any_ exception, we return a 500 error with an error message
+    response = {
+      'statusCode' => 500,
+      'body' => exception.message
+    }
+  end
+
+  # By default, the response serializer will call #to_json for us
+  response
+end


### PR DESCRIPTION
Using https://github.com/aws-samples/serverless-sinatra-sample as a starting point.

For deployment:

- `make` will create a `lambda.zip` that can be uploaded to AWS
- The environment variable `APPROOT` needs to be set to the API Gateway base URL
- API Gateway should forward everything to the lambda function, this requires two a "proxy" resource and a "ANY" method for `/` (see screenshot)

![screen](https://user-images.githubusercontent.com/461132/68306540-4e9df000-00dc-11ea-8c4a-29c5bc6d2d15.png)